### PR TITLE
Alpha assert is wrong

### DIFF
--- a/Gradients/Sources/Color+Extension.swift
+++ b/Gradients/Sources/Color+Extension.swift
@@ -12,7 +12,7 @@ extension UIColor {
         assert(red >= 0 && red <= 255, "Invalid red component")
         assert(green >= 0 && green <= 255, "Invalid green component")
         assert(blue >= 0 && blue <= 255, "Invalid blue component")
-        assert(alpha >= 0 && alpha <= 255, "Invalid alpha component")
+        assert(alpha >= 0.0 && alpha <= 1.0, "Invalid alpha component")
         
         self.init(red: CGFloat(red) / 255.0,
                   green: CGFloat(green) / 255.0,


### PR DESCRIPTION
Alpha value is must be between 0.0 and 1.0

```
alpha
The opacity value of the color object, specified as a value from 0.0 to 1.0. Alpha values below 0.0 are interpreted as 0.0, and values above 1.0 are interpreted as 1.0.
```