### PR TITLE
Remove unnecessary return

### DIFF
--- a/Gradients/Sources/Color+Extension.swift
+++ b/Gradients/Sources/Color+Extension.swift
@@ -32,6 +32,6 @@ extension UIColor {
 
 extension Int {
     var cgColor: CGColor {
-        return UIColor(self).cgColor
+        UIColor(self).cgColor
     }
 }


### PR DESCRIPTION
Tiny change but from Swift 5 onward `return` can be omitted on single line computed properties.